### PR TITLE
Introduce `created_by` and `updated_by` columns. Add triggers

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -63,14 +63,6 @@ CREATE TABLE contract_deployments
     /* an opaque id*/
     id  uuid NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
 
-    /* timestamps */
-    created_at  timestamptz NOT NULL DEFAULT NOW(),
-    updated_at  timestamptz NOT NULL DEFAULT NOW(),
-
-    /* ownership */
-    created_by  varchar NOT NULL DEFAULT (current_user),
-    updated_by  varchar NOT NULL DEFAULT (current_user),
-
     /*
         these three fields uniquely identify a specific deployment of a contract, assuming
         that it is impossible to deploy to successfully an address twice in the same transaction
@@ -352,8 +344,7 @@ $$
     DECLARE
         t_name text;
     BEGIN
-        FOR t_name IN (VALUES ('contract_deployments'),
-                              ('compiled_contracts'),
+        FOR t_name IN (VALUES ('compiled_contracts'),
                               ('verified_contracts'))
             LOOP
                 EXECUTE format('CREATE TRIGGER insert_set_created_by


### PR DESCRIPTION
Database schema suggestions:

1.  Add ownership related columns (`created_by`, `updated_by`). Would help to identify buggy implementations in case if  invalid sources are found. Besides, would help to setup rules according to which only the user inserted an instance should be able to modify or update it.

    Currently added to all but `code` and `contracts` tables (`contract_deployments`, `compiled_contracts`, and `verified_contracts`). It just seems that there is not lot of things to make mistake at with `code` or `contracts` tables. But may add the ownership columns for them as well, would be glad to discuss.

2. Add automatic setup of 'created_by', 'updated_by', 'created_at', and 'updated_at' columns via triggers. That sets up and enforces rules of how those values should be set and modified. 