### PR TITLE
Add valid code_hash constraint to database.sql

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -15,7 +15,7 @@ CREATE EXTENSION pgcrypto;
 */
 CREATE TABLE code
 (
-    /* the sha3-256 hash of the `code` column */
+    /* the sha256 hash of the `code` column */
     code_hash   bytea NOT NULL PRIMARY KEY,
 
     /*
@@ -31,7 +31,7 @@ CREATE TABLE code
     code    bytea
 
     CONSTRAINT code_hash_check
-        CHECK (code IS NOT NULL and code_hash = digest(code, 'sha3-256') or code IS NULL and code_hash = '\x'::bytea)
+        CHECK (code IS NOT NULL and code_hash = digest(code, 'sha256') or code IS NULL and code_hash = '\x'::bytea)
 );
 
 CREATE INDEX code_code_hash_keccak ON code USING btree(code_hash_keccak);

--- a/database.sql
+++ b/database.sql
@@ -1,4 +1,4 @@
-/* Needed for gen_random_uuid(); */
+/* Needed for gen_random_uuid() and digest(..) */
 CREATE EXTENSION pgcrypto;
 
 /*
@@ -15,11 +15,14 @@ CREATE EXTENSION pgcrypto;
 */
 CREATE TABLE code
 (
-    /* the keccak256 hash of the `code` column */
+    /* the sha3-256 hash of the `code` column */
     code_hash   bytea NOT NULL PRIMARY KEY,
 
     /* the bytecode */
     code    bytea
+
+    CONSTRAINT code_hash_check
+        CHECK (code IS NOT NULL and code_hash = digest(code, 'sha3-256') or code IS NULL and code_hash = '\x'::bytea)
 );
 
 /* ensure the sentinel value exists */

--- a/database.sql
+++ b/database.sql
@@ -18,6 +18,15 @@ CREATE TABLE code
     /* the sha3-256 hash of the `code` column */
     code_hash   bytea NOT NULL PRIMARY KEY,
 
+    /*
+        the keccak256 hash of the `code` column
+
+        can be useful for lookups, as keccak256 is more common for Ethereum
+        but we cannot use it as a primary key because postgres does not support the keccak256, and
+        we cannot guarantee at the database level that provided value is the correct `code` hash
+    */
+    code_hash_keccak bytea NOT NULL,
+
     /* the bytecode */
     code    bytea
 
@@ -25,8 +34,10 @@ CREATE TABLE code
         CHECK (code IS NOT NULL and code_hash = digest(code, 'sha3-256') or code IS NULL and code_hash = '\x'::bytea)
 );
 
+CREATE INDEX code_code_hash_keccak ON code USING btree(code_hash_keccak);
+
 /* ensure the sentinel value exists */
-INSERT INTO code (code_hash, code) VALUES ('\x', NULL);
+INSERT INTO code (code_hash, code_hash_keccak, code) VALUES ('\x', '\x', NULL);
 
 /*
     The `contracts` table stores information which can be used to identify a unique contract in a


### PR DESCRIPTION
Make use of sha256 instead of keccak256 as a `code.code_hash` definition.  Add a constraint to guarantee that invariant on the database level