### PR TITLE
Add missing timestamp and ownership fields

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -18,6 +18,14 @@ CREATE TABLE code
     /* the sha256 hash of the `code` column */
     code_hash   bytea NOT NULL PRIMARY KEY,
 
+    /* timestamps */
+    created_at  timestamptz NOT NULL DEFAULT NOW(),
+    updated_at  timestamptz NOT NULL DEFAULT NOW(),
+
+    /* ownership */
+    created_by  varchar NOT NULL DEFAULT (current_user),
+    updated_by  varchar NOT NULL DEFAULT (current_user),
+
     /*
         the keccak256 hash of the `code` column
 
@@ -50,6 +58,14 @@ CREATE TABLE contracts
     /* an opaque id */
     id  uuid NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
 
+    /* timestamps */
+    created_at  timestamptz NOT NULL DEFAULT NOW(),
+    updated_at  timestamptz NOT NULL DEFAULT NOW(),
+
+    /* ownership */
+    created_by  varchar NOT NULL DEFAULT (current_user),
+    updated_by  varchar NOT NULL DEFAULT (current_user),
+
     /*
         the creation code is the calldata (for eoa creations) or the instruction input (for create/create2)
         the runtime code is the bytecode that's returned by the creation code and stored on-chain
@@ -76,6 +92,14 @@ CREATE TABLE contract_deployments
 (
     /* an opaque id*/
     id  uuid NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    /* timestamps */
+    created_at  timestamptz NOT NULL DEFAULT NOW(),
+    updated_at  timestamptz NOT NULL DEFAULT NOW(),
+
+    /* ownership */
+    created_by  varchar NOT NULL DEFAULT (current_user),
+    updated_by  varchar NOT NULL DEFAULT (current_user),
 
     /*
         these three fields uniquely identify a specific deployment of a contract, assuming
@@ -272,7 +296,7 @@ $$ LANGUAGE plpgsql;
 CREATE FUNCTION trigger_set_updated_at()
 RETURNS TRIGGER AS $$
 BEGIN
-    NEW.updated_by = NOW();
+    NEW.updated_at = NOW();
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
@@ -282,7 +306,10 @@ $$
     DECLARE
         t_name text;
     BEGIN
-        FOR t_name IN (VALUES ('compiled_contracts'),
+        FOR t_name IN (VALUES ('code'),
+                              ('contracts'),
+                              ('contract_deployments'),
+                              ('compiled_contracts'),
                               ('verified_contracts'))
             LOOP
                 EXECUTE format('CREATE TRIGGER insert_set_created_at
@@ -358,7 +385,10 @@ $$
     DECLARE
         t_name text;
     BEGIN
-        FOR t_name IN (VALUES ('compiled_contracts'),
+        FOR t_name IN (VALUES ('code'),
+                              ('contracts'),
+                              ('contract_deployments'),
+                              ('compiled_contracts'),
                               ('verified_contracts'))
             LOOP
                 EXECUTE format('CREATE TRIGGER insert_set_created_by


### PR DESCRIPTION
* To `code`, `contracts`, and `contract_deployments` tables
* Fix `trigger_set_updated_add` to use `updated_at` field instead of incorrect `updated_by`