### PR TITLE
Add runtime_metadata_match, creation_metadata_match

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -228,12 +228,12 @@ CREATE TABLE verified_contracts
     creation_match              bool NOT NULL,
     creation_values             jsonb,
     creation_transformations    jsonb,
-    creation_metadata_match     bool NOT NULL,
+    creation_metadata_match     bool,
 
     runtime_match           bool NOT NULL,
     runtime_values          jsonb,
     runtime_transformations jsonb,
-    runtime_metadata_match  bool NOT NULL,
+    runtime_metadata_match  bool,
 
     CONSTRAINT verified_contracts_pseudo_pkey UNIQUE (compilation_id, deployment_id),
 
@@ -250,11 +250,11 @@ CREATE TABLE verified_contracts
     CONSTRAINT verified_contracts_match_exists 
         CHECK (creation_match = true OR runtime_match = true),
     CONSTRAINT verified_contracts_creation_match_integrity
-        CHECK ((creation_match = false AND creation_values IS NULL AND creation_transformations IS NULL) OR
-               (creation_match = true AND creation_values IS NOT NULL AND creation_transformations IS NOT NULL)),
+        CHECK ((creation_match = false AND creation_values IS NULL AND creation_transformations IS NULL AND creation_metadata_match IS NULL) OR
+               (creation_match = true AND creation_values IS NOT NULL AND creation_transformations IS NOT NULL AND creation_metadata_match IS NOT NULL)),
     CONSTRAINT verified_contracts_runtime_match_integrity
-        CHECK ((runtime_match = false AND runtime_values IS NULL AND runtime_transformations IS NULL) OR
-               (runtime_match = true AND runtime_values IS NOT NULL AND runtime_transformations IS NOT NULL))
+        CHECK ((runtime_match = false AND runtime_values IS NULL AND runtime_transformations IS NULL AND runtime_metadata_match IS NULL) OR
+                (runtime_match = true AND runtime_values IS NOT NULL AND runtime_transformations IS NOT NULL AND runtime_metadata_match IS NOT NULL));
 );
 
 CREATE INDEX verified_contracts_deployment_id ON verified_contracts USING btree (deployment_id);

--- a/database.sql
+++ b/database.sql
@@ -228,10 +228,12 @@ CREATE TABLE verified_contracts
     creation_match              bool NOT NULL,
     creation_values             jsonb,
     creation_transformations    jsonb,
+    creation_metadata_match     bool NOT NULL,
 
     runtime_match           bool NOT NULL,
     runtime_values          jsonb,
     runtime_transformations jsonb,
+    runtime_metadata_match  bool NOT NULL,
 
     CONSTRAINT verified_contracts_pseudo_pkey UNIQUE (compilation_id, deployment_id),
 

--- a/database.sql
+++ b/database.sql
@@ -254,7 +254,7 @@ CREATE TABLE verified_contracts
                (creation_match = true AND creation_values IS NOT NULL AND creation_transformations IS NOT NULL AND creation_metadata_match IS NOT NULL)),
     CONSTRAINT verified_contracts_runtime_match_integrity
         CHECK ((runtime_match = false AND runtime_values IS NULL AND runtime_transformations IS NULL AND runtime_metadata_match IS NULL) OR
-                (runtime_match = true AND runtime_values IS NOT NULL AND runtime_transformations IS NOT NULL AND runtime_metadata_match IS NOT NULL));
+                (runtime_match = true AND runtime_values IS NOT NULL AND runtime_transformations IS NOT NULL AND runtime_metadata_match IS NOT NULL))
 );
 
 CREATE INDEX verified_contracts_deployment_id ON verified_contracts USING btree (deployment_id);


### PR DESCRIPTION
New columns in `verified_contracts`:
- `runtime_metadata_match`
- `creation_metadata_match`

Rules:
- If the contract has auxdata transformation, set metadata_match as false
- If the contract has no metadata hash, set metadata_match fields to false
- If the contract has the metadata hash and no auxdata transformation set metadata_match to true