### PR TITLE
feat(verified_contracts-values) - add `verified_contracts` creation and runtime values constraints

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -418,11 +418,13 @@ CREATE OR REPLACE FUNCTION validate_creation_values(obj jsonb)
     RETURNS boolean AS
 $$
 BEGIN
-    RETURN validate_json_object_keys(
-        obj, 
-        array []::text[],
-        array ['libraries', 'cborAuxdata', 'constructorArguments']
-    );
+    RETURN 
+        is_object(obj) AND 
+        validate_json_object_keys(
+            obj, 
+            array []::text[],
+            array ['libraries', 'cborAuxdata', 'constructorArguments']
+        );
 END;
 $$ LANGUAGE plpgsql;
 
@@ -430,11 +432,12 @@ CREATE OR REPLACE FUNCTION validate_runtime_values(obj jsonb)
     RETURNS boolean AS
 $$
 BEGIN
-    RETURN validate_json_object_keys(
-        obj, 
-        array []::text[],
-        array ['libraries', 'cborAuxdata', 'immutables', 'callProtection']
-    );
+    RETURN is_object(obj) AND 
+        validate_json_object_keys(
+            obj, 
+            array []::text[],
+            array ['libraries', 'cborAuxdata', 'immutables', 'callProtection']
+        );
 END;
 $$ LANGUAGE plpgsql;
 

--- a/database.sql
+++ b/database.sql
@@ -331,15 +331,6 @@ CREATE INDEX verified_contracts_compilation_id ON verified_contracts USING btree
 /*
     Helper functions used to ensure the correctness of json objects.
 */
-CREATE OR REPLACE FUNCTION is_object(obj jsonb)
-    RETURNS boolean AS
-$$
-BEGIN
-    RETURN
-        jsonb_typeof(obj) = 'object';
-END;
-$$ LANGUAGE plpgsql;
-
 CREATE OR REPLACE FUNCTION is_jsonb_object(obj jsonb)
     RETURNS boolean AS
 $$
@@ -387,7 +378,7 @@ CREATE OR REPLACE FUNCTION validate_compilation_artifacts(obj jsonb)
 $$
 BEGIN
     RETURN 
-        is_object(obj) AND 
+        is_jsonb_object(obj) AND
         validate_json_object_keys(
             obj, 
             array ['abi', 'userdoc', 'devdoc', 'sources', 'storageLayout'],
@@ -401,7 +392,7 @@ CREATE OR REPLACE FUNCTION validate_creation_code_artifacts(obj jsonb)
 $$
 BEGIN
     RETURN 
-        is_object(obj) AND 
+        is_jsonb_object(obj) AND
         validate_json_object_keys(
             obj, 
             array ['sourceMap', 'linkReferences'], 
@@ -415,7 +406,7 @@ CREATE OR REPLACE FUNCTION validate_runtime_code_artifacts(obj jsonb)
 $$
 BEGIN
     RETURN 
-        is_object(obj) AND 
+        is_jsonb_object(obj) AND
         validate_json_object_keys(
             obj, 
             array ['sourceMap', 'linkReferences', 'immutableReferences'],

--- a/database.sql
+++ b/database.sql
@@ -411,6 +411,41 @@ ALTER TABLE compiled_contracts
 ADD CONSTRAINT runtime_code_artifacts_object 
 CHECK (validate_runtime_code_artifacts(runtime_code_artifacts));
 
+/*
+    Validation functions to be used in `verified_contracts` values constraints.
+*/
+CREATE OR REPLACE FUNCTION validate_creation_values(obj jsonb)
+    RETURNS boolean AS
+$$
+BEGIN
+    RETURN validate_json_object_keys(
+        obj, 
+        array []::text[],
+        array ['libraries', 'cborAuxdata', 'constructorArguments']
+    );
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION validate_runtime_values(obj jsonb)
+    RETURNS boolean AS
+$$
+BEGIN
+    RETURN validate_json_object_keys(
+        obj, 
+        array []::text[],
+        array ['libraries', 'cborAuxdata', 'immutables', 'callProtection']
+    );
+END;
+$$ LANGUAGE plpgsql;
+
+ALTER TABLE verified_contracts
+ADD CONSTRAINT creation_values_object 
+CHECK (validate_creation_values(creation_values));
+
+ALTER TABLE verified_contracts
+ADD CONSTRAINT runtime_values_object 
+CHECK (validate_runtime_values(runtime_values));
+
 /* 
     Set up timestamps related triggers. Used to enforce `created_at` and `updated_at` 
     specific rules and prevent users to set those columns to invalid values.

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -32,6 +32,57 @@ class Code:
             """, (self.code_hash, self.code_hash_keccak, self.code))
 
 
+class Contract:
+    id = ""
+
+    @staticmethod
+    def dummy():
+        instance = Contract()
+        instance.id = 'df8fd690-70a8-4dd8-b42b-5c12e5d05dbe'
+        return instance
+
+    def insert(self, connection, creation_code_hash, runtime_code_hash):
+        with connection.cursor() as cursor:
+            cursor.execute("""
+                INSERT INTO contracts (id, creation_code_hash, runtime_code_hash)
+                VALUES (%s, %s, %s)
+            """, (self.id, creation_code_hash, runtime_code_hash))
+
+
+class ContractDeployment:
+    id = ""
+    chain_id = 0
+    address = b''
+    transaction_hash = b''
+    block_number = 0
+    transaction_index = 0
+    deployer = b''
+
+    @staticmethod
+    def dummy():
+        instance = ContractDeployment()
+        instance.id = '42d20697-5427-4130-adbd-97daab2b2dd1'
+        instance.chain_id = 1
+        instance.address = bytes.fromhex(
+            '0000000000000000000000000000000000000000')
+        instance.transaction_hash = bytes.fromhex(
+            '0000000000000000000000000000000000000000000000000000000000000000')
+        instance.block_number = -1
+        instance.transaction_index = -1
+        instance.deployer = '0000000000000000000000000000000000000000'
+        return instance
+
+    def insert(self, connection, contract_id):
+        with connection.cursor() as cursor:
+            cursor.execute("""
+                INSERT INTO contract_deployments (
+                    id, chain_id, address, transaction_hash,
+                    block_number, transaction_index, deployer, contract_id)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            """, (self.id, self.chain_id, self.address, self.transaction_hash,
+                  self.block_number, self.transaction_index, self.deployer, contract_id))
+
+
 class CompiledContract:
     id = ""
     compiler = ""
@@ -83,6 +134,48 @@ class CompiledContract:
                   runtime_code_hash, json.dumps(self.runtime_code_artifacts)))
 
 
+class VerifiedContract:
+    id = ""
+    creation_match = False
+    creation_values = None
+    creation_transformations = None
+    creation_metadata_match = None
+    runtime_match = False
+    runtime_values = None
+    runtime_transformations = None
+    runtime_metadata_match = None
+
+    @staticmethod
+    def dummy():
+        instance = VerifiedContract()
+        instance.id = 1
+        instance.creation_match = True
+        instance.creation_values = dict()
+        instance.creation_transformations = []
+        instance.creation_metadata_match = True
+        instance.runtime_match = True
+        instance.runtime_values = dict()
+        instance.runtime_transformations = []
+        instance.runtime_metadata_match = True
+
+        return instance
+
+    def insert(self, connection, deployment_id, compilation_id):
+        with connection.cursor() as cursor:
+            cursor.execute("""
+                INSERT INTO verified_contracts (
+                    id, deployment_id, compilation_id,
+                    creation_match, creation_values, creation_transformations, creation_metadata_match,
+                    runtime_match, runtime_values, runtime_transformations, runtime_metadata_match)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """, (self.id, deployment_id, compilation_id,
+                  self.creation_match, json.dumps(self.creation_values),
+                  json.dumps(
+                      self.creation_transformations), self.creation_metadata_match,
+                  self.runtime_match, json.dumps(self.runtime_values),
+                  json.dumps(self.runtime_transformations), self.runtime_metadata_match))
+
+
 @pytest.fixture(scope="function", autouse=True)
 def initialize(connection):
     initialize_schema(connection)
@@ -107,8 +200,23 @@ def dummy_code() -> Code:
 
 
 @pytest.fixture
-def dummy_compiled_contract(dummy_code):
+def dummy_contract() -> Contract:
+    return Contract.dummy()
+
+
+@pytest.fixture
+def dummy_contract_deployment():
+    return ContractDeployment.dummy()
+
+
+@pytest.fixture
+def dummy_compiled_contract():
     return CompiledContract.dummy()
+
+
+@pytest.fixture
+def dummy_verified_contract():
+    return VerifiedContract.dummy()
 
 
 def initialize_schema(connection):

--- a/tests/test_constraint_creation_values.py
+++ b/tests/test_constraint_creation_values.py
@@ -1,15 +1,20 @@
 from helpers import *
 
 
-class TestCreationValuesObjectConstraint:
+def setup(connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
+    dummy_code.insert(connection)
+    dummy_contract.insert(
+        connection, dummy_code.code_hash, dummy_code.code_hash)
+    dummy_contract_deployment.insert(connection, dummy_contract.id)
+    dummy_compiled_contract.insert(
+        connection, dummy_code.code_hash, dummy_code.code_hash)
+
+
+class TestObject:
     @pytest.fixture(scope='function', autouse=True)
     def setup(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
-        dummy_code.insert(connection)
-        dummy_contract.insert(
-            connection, dummy_code.code_hash, dummy_code.code_hash)
-        dummy_contract_deployment.insert(connection, dummy_contract.id)
-        dummy_compiled_contract.insert(
-            connection, dummy_code.code_hash, dummy_code.code_hash)
+        setup(connection, dummy_code, dummy_contract,
+              dummy_contract_deployment, dummy_compiled_contract)
 
     def test_no_fields_are_required(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
         dummy_verified_contract.creation_values = dict({})
@@ -21,17 +26,6 @@ class TestCreationValuesObjectConstraint:
             "constructorArguments": "0x1234",
             "libraries": {"file1:lib1": "0x4000000000000000000000000000000000000000"},
             "cborAuxdata": {"1": "0x00000000000000000000000000000000000000000000000000000000000000000000000000"}
-        })
-        dummy_verified_contract.insert(
-            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
-
-    # This test shows that empty json objects instead of libraries are also allowed according to schema.
-    # TODO: should they actually be allowed?
-    def test_default_type_values(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
-        dummy_verified_contract.creation_values = dict({
-            "constructorArguments": "0x1234",
-            "libraries": {},
-            "cborAuxdata": {}
         })
         dummy_verified_contract.insert(
             connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
@@ -52,6 +46,261 @@ class TestCreationValuesObjectConstraint:
 
     def test_unknown_field_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
         dummy_verified_contract.creation_values['unknown_key'] = dict({})
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")
+
+
+########## Tests constructorArguments field constraints ##########
+class TestObjectConstructorArguments:
+    @pytest.fixture(scope='function', autouse=True)
+    def setup(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
+        setup(connection, dummy_code, dummy_contract,
+              dummy_contract_deployment, dummy_compiled_contract)
+
+    def test_valid_field_value(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "constructorArguments": "0x1234"
+        })
+        dummy_verified_contract.insert(
+            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
+
+    @pytest.mark.parametrize("value", [None, [], dict()], ids=["null", "array", "object"])
+    def test_invalid_type_fails(self, value, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "constructorArguments": value
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")
+
+    def test_without_0x_prefix_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "constructorArguments": "1234"
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")
+
+    def test_not_valid_hex_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "constructorArguments": "0xqwer"
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")
+
+    def test_empty_hex_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "constructorArguments": "0x"
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")
+
+    def test_odd_length_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "constructorArguments": "0x123"
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")
+
+########## Tests libraries field constraints ##########
+
+
+class TestObjectLibraries:
+    @pytest.fixture(scope='function', autouse=True)
+    def setup(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
+        setup(connection, dummy_code, dummy_contract,
+              dummy_contract_deployment, dummy_compiled_contract)
+
+    def test_valid_field_value(self, connection, dummy_code, dummy_contract,
+                               dummy_contract_deployment, dummy_compiled_contract,
+                               dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "libraries": {"file1:lib1": "0x4000000000000000000000000000000000000000"}
+        })
+        dummy_verified_contract.insert(
+            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
+
+    def test_empty_object(self, connection, dummy_code, dummy_contract,
+                          dummy_contract_deployment, dummy_compiled_contract,
+                          dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "libraries": {}
+        })
+        dummy_verified_contract.insert(
+            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
+
+    @pytest.mark.parametrize("value", [None, [], ""], ids=["null", "array", "string"])
+    def test_invalid_type_fails(self, value, connection, dummy_code, dummy_contract,
+                                dummy_contract_deployment, dummy_compiled_contract,
+                                dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "libraries": value
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")
+
+    @pytest.mark.parametrize("value", [None, [], dict({})], ids=["null", "array", "object"])
+    def test_additional_properties_with_invalid_type_fails(self, value, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                                           dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "libraries": {"file1:lib1": value}
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")
+
+    def test_values_without_0x_prefix_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                            dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "libraries": {"file1:lib1": "4000000000000000000000000000000000000000000000000"}
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")
+
+    def test_values_not_valid_hex_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                        dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "libraries": {"file1:lib1": "0xqw00000000000000000000000000000000000000000000000"}
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")
+
+    def test_values_not_20_bytes_hex_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                           dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "libraries": {"file1:lib1": "0x1000000000"}
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")
+
+    def test_values_one_fail_all_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                       dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "libraries": {
+                "file1:lib1": "4000000000000000000000000000000000000000000000000",
+                "file2:lib2": "0x4000000000000000000000000000000000000000000000000"
+            }
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")
+
+########## Tests cborAuxdata field constraints ##########
+
+
+class TestObjectCborAuxdata:
+    @pytest.fixture(scope='function', autouse=True)
+    def setup(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
+        setup(connection, dummy_code, dummy_contract,
+              dummy_contract_deployment, dummy_compiled_contract)
+
+    def test_valid_field_value(self, connection, dummy_code, dummy_contract,
+                               dummy_contract_deployment, dummy_compiled_contract,
+                               dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "cborAuxdata": {"1": "0x00000000000000000000000000000000000000000000000000000000000000000000000000"}
+        })
+        dummy_verified_contract.insert(
+            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
+
+    def test_empty_object(self, connection, dummy_code, dummy_contract,
+                          dummy_contract_deployment, dummy_compiled_contract,
+                          dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "cborAuxdata": {}
+        })
+        dummy_verified_contract.insert(
+            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
+
+    @pytest.mark.parametrize("value", [None, [], ""], ids=["null", "array", "string"])
+    def test_invalid_type_fails(self, value, connection, dummy_code, dummy_contract,
+                                dummy_contract_deployment, dummy_compiled_contract,
+                                dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "cborAuxdata": value
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")
+
+    @pytest.mark.parametrize("value", [None, [], dict({})], ids=["null", "array", "object"])
+    def test_additional_properties_with_invalid_type_fails(self, value, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                                           dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "cborAuxdata": {"1": value}
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")
+
+    def test_values_without_0x_prefix_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                            dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "cborAuxdata": {"1": "00000000000000000000000000000000000000000000000000000000000000000000000000"}
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")
+
+    def test_values_not_valid_hex_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                        dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "cborAuxdata": {"1": "0xqwer0000000000000000000000000000000000000000000000000000000000000000000000"}
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")
+
+    def test_empty_hex_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "cborAuxdata": {"1": "0x"}
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")
+
+    def test_odd_length_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "cborAuxdata": {"1": "0x123"}
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")
+
+    def test_values_one_fail_all_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                       dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "cborAuxdata": {
+                "1": "0x00000000000000000000000000000000000000000000000000000000000000000000000000",
+                "2": "00000000000000000000000000000000000000000000000000000000000000000000000000"
+            }
+        })
         check_constraint_fails(
             lambda: dummy_verified_contract.insert(
                 connection, dummy_contract_deployment.id, dummy_compiled_contract.id),

--- a/tests/test_constraint_creation_values.py
+++ b/tests/test_constraint_creation_values.py
@@ -1,0 +1,58 @@
+from helpers import *
+
+
+class TestCreationValuesObjectConstraint:
+    @pytest.fixture(scope='function', autouse=True)
+    def setup(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
+        dummy_code.insert(connection)
+        dummy_contract.insert(
+            connection, dummy_code.code_hash, dummy_code.code_hash)
+        dummy_contract_deployment.insert(connection, dummy_contract.id)
+        dummy_compiled_contract.insert(
+            connection, dummy_code.code_hash, dummy_code.code_hash)
+
+    def test_no_fields_are_required(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({})
+        dummy_verified_contract.insert(
+            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
+
+    def test_expected_type_values(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "constructorArguments": "0x1234",
+            "libraries": {"file1:lib1": "0x4000000000000000000000000000000000000000"},
+            "cborAuxdata": {"1": "0x00000000000000000000000000000000000000000000000000000000000000000000000000"}
+        })
+        dummy_verified_contract.insert(
+            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
+
+    # This test shows that empty json objects instead of libraries are also allowed according to schema.
+    # TODO: should they actually be allowed?
+    def test_default_type_values(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values = dict({
+            "constructorArguments": "0x1234",
+            "libraries": {},
+            "cborAuxdata": {}
+        })
+        dummy_verified_contract.insert(
+            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
+
+    def test_invalid_json_type_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values = "just a string"
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")
+
+    def test_immutables_field_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values["immutables"] = dict({})
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")
+
+    def test_unknown_field_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values['unknown_key'] = dict({})
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")

--- a/tests/test_constraint_creation_values.py
+++ b/tests/test_constraint_creation_values.py
@@ -1,6 +1,7 @@
 from helpers import *
 
 
+@pytest.fixture(scope='function', autouse=True)
 def setup(connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
     dummy_code.insert(connection)
     dummy_contract.insert(
@@ -11,11 +12,6 @@ def setup(connection, dummy_code, dummy_contract, dummy_contract_deployment, dum
 
 
 class TestObject:
-    @pytest.fixture(scope='function', autouse=True)
-    def setup(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
-        setup(connection, dummy_code, dummy_contract,
-              dummy_contract_deployment, dummy_compiled_contract)
-
     def test_no_fields_are_required(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
         dummy_verified_contract.creation_values = dict({})
         dummy_verified_contract.insert(
@@ -61,11 +57,6 @@ class TestObject:
 
 ########## Tests constructorArguments field constraints ##########
 class TestObjectConstructorArguments:
-    @pytest.fixture(scope='function', autouse=True)
-    def setup(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
-        setup(connection, dummy_code, dummy_contract,
-              dummy_contract_deployment, dummy_compiled_contract)
-
     def test_valid_field_value(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
         dummy_verified_contract.creation_values = dict({
             "constructorArguments": "0x1234"
@@ -119,15 +110,9 @@ class TestObjectConstructorArguments:
                 connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
             "creation_values_object")
 
+
 ########## Tests libraries field constraints ##########
-
-
 class TestObjectLibraries:
-    @pytest.fixture(scope='function', autouse=True)
-    def setup(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
-        setup(connection, dummy_code, dummy_contract,
-              dummy_contract_deployment, dummy_compiled_contract)
-
     def test_valid_field_value(self, connection, dummy_code, dummy_contract,
                                dummy_contract_deployment, dummy_compiled_contract,
                                dummy_verified_contract):
@@ -212,15 +197,9 @@ class TestObjectLibraries:
                 connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
             "creation_values_object")
 
+
 ########## Tests cborAuxdata field constraints ##########
-
-
 class TestObjectCborAuxdata:
-    @pytest.fixture(scope='function', autouse=True)
-    def setup(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
-        setup(connection, dummy_code, dummy_contract,
-              dummy_contract_deployment, dummy_compiled_contract)
-
     def test_valid_field_value(self, connection, dummy_code, dummy_contract,
                                dummy_contract_deployment, dummy_compiled_contract,
                                dummy_verified_contract):

--- a/tests/test_constraint_creation_values.py
+++ b/tests/test_constraint_creation_values.py
@@ -44,6 +44,13 @@ class TestObject:
                 connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
             "creation_values_object")
 
+    def test_call_protection_field_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_values["callProtection"] = "0x4000000000000000000000000000000000000000"
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "creation_values_object")
+
     def test_unknown_field_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
         dummy_verified_contract.creation_values['unknown_key'] = dict({})
         check_constraint_fails(

--- a/tests/test_constraint_runtime_values.py
+++ b/tests/test_constraint_runtime_values.py
@@ -1,15 +1,20 @@
 from helpers import *
 
 
-class TestRuntimeValuesObjectConstraint:
+def setup(connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
+    dummy_code.insert(connection)
+    dummy_contract.insert(
+        connection, dummy_code.code_hash, dummy_code.code_hash)
+    dummy_contract_deployment.insert(connection, dummy_contract.id)
+    dummy_compiled_contract.insert(
+        connection, dummy_code.code_hash, dummy_code.code_hash)
+
+
+class TestObject:
     @pytest.fixture(scope='function', autouse=True)
     def setup(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
-        dummy_code.insert(connection)
-        dummy_contract.insert(
-            connection, dummy_code.code_hash, dummy_code.code_hash)
-        dummy_contract_deployment.insert(connection, dummy_contract.id)
-        dummy_compiled_contract.insert(
-            connection, dummy_code.code_hash, dummy_code.code_hash)
+        setup(connection, dummy_code, dummy_contract,
+              dummy_contract_deployment, dummy_compiled_contract)
 
     def test_no_fields_are_required(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
         dummy_verified_contract.runtime_values = dict({})
@@ -19,19 +24,8 @@ class TestRuntimeValuesObjectConstraint:
     def test_expected_type_values(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
         dummy_verified_contract.runtime_values = dict({
             "libraries": {"file1:lib1": "0x4000000000000000000000000000000000000000"},
-            "immutables": {"123": "0x0000000000000000000000000000000000000000000000000000000000000000"},
+            "immutables": {"123": "0x6400000000000000000000000000000000000000000000000000000000000000"},
             "cborAuxdata": {"1": "0x00000000000000000000000000000000000000000000000000000000000000000000000000"}
-        })
-        dummy_verified_contract.insert(
-            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
-
-    # This test shows that empty json objects instead of libraries are also allowed according to schema.
-    # TODO: should they actually be allowed?
-    def test_default_type_values(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
-        dummy_verified_contract.runtime_values = dict({
-            "libraries": {},
-            "immutables": {},
-            "cborAuxdata": {}
         })
         dummy_verified_contract.insert(
             connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
@@ -53,6 +47,292 @@ class TestRuntimeValuesObjectConstraint:
 
     def test_unknown_field_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
         dummy_verified_contract.runtime_values['unknown_key'] = dict({})
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")
+
+
+########## Tests libraries field constraints ##########
+class TestObjectLibraries:
+    @pytest.fixture(scope='function', autouse=True)
+    def setup(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
+        setup(connection, dummy_code, dummy_contract,
+              dummy_contract_deployment, dummy_compiled_contract)
+
+    def test_valid_field_value(self, connection, dummy_code, dummy_contract,
+                               dummy_contract_deployment, dummy_compiled_contract,
+                               dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "libraries": {"file1:lib1": "0x4000000000000000000000000000000000000000"}
+        })
+        dummy_verified_contract.insert(
+            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
+
+    def test_empty_object(self, connection, dummy_code, dummy_contract,
+                          dummy_contract_deployment, dummy_compiled_contract,
+                          dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "libraries": {}
+        })
+        dummy_verified_contract.insert(
+            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
+
+    @pytest.mark.parametrize("value", [None, [], ""], ids=["null", "array", "string"])
+    def test_invalid_type_fails(self, value, connection, dummy_code, dummy_contract,
+                                dummy_contract_deployment, dummy_compiled_contract,
+                                dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "libraries": value
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")
+
+    @pytest.mark.parametrize("value", [None, [], dict({})], ids=["null", "array", "object"])
+    def test_additional_properties_with_invalid_type_fails(self, value, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                                           dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "libraries": {"file1:lib1": value}
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")
+
+    def test_values_without_0x_prefix_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                            dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "libraries": {"file1:lib1": "4000000000000000000000000000000000000000000000000"}
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")
+
+    def test_values_not_valid_hex_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                        dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "libraries": {"file1:lib1": "0xqw00000000000000000000000000000000000000000000000"}
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")
+
+    def test_values_not_20_bytes_hex_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                           dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "libraries": {"file1:lib1": "0x1000000000"}
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")
+
+    def test_values_one_fail_all_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                       dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "libraries": {
+                "file1:lib1": "4000000000000000000000000000000000000000000000000",
+                "file2:lib2": "0x4000000000000000000000000000000000000000000000000"
+            }
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")
+
+########## Tests immutables field constraints ##########
+
+
+class TestObjectImmutables:
+    @pytest.fixture(scope='function', autouse=True)
+    def setup(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
+        setup(connection, dummy_code, dummy_contract,
+              dummy_contract_deployment, dummy_compiled_contract)
+
+    def test_valid_field_value(self, connection, dummy_code, dummy_contract,
+                               dummy_contract_deployment, dummy_compiled_contract,
+                               dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "immutables": {"123": "0x6400000000000000000000000000000000000000000000000000000000000000"},
+        })
+        dummy_verified_contract.insert(
+            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
+
+    def test_empty_object(self, connection, dummy_code, dummy_contract,
+                          dummy_contract_deployment, dummy_compiled_contract,
+                          dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "immutables": {}
+        })
+        dummy_verified_contract.insert(
+            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
+
+    @pytest.mark.parametrize("value", [None, [], ""], ids=["null", "array", "string"])
+    def test_invalid_type_fails(self, value, connection, dummy_code, dummy_contract,
+                                dummy_contract_deployment, dummy_compiled_contract,
+                                dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "immutables": value
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")
+
+    @pytest.mark.parametrize("value", [None, [], dict({})], ids=["null", "array", "object"])
+    def test_additional_properties_with_invalid_type_fails(self, value, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                                           dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "immutables": {"123": value},
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")
+
+    def test_values_without_0x_prefix_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                            dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "immutables": {"123": "6400000000000000000000000000000000000000000000000000000000000000"},
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")
+
+    def test_values_not_valid_hex_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                        dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "immutables": {"123": "0xqwer000000000000000000000000000000000000000000000000000000000000"},
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")
+
+    def test_values_not_32_bytes_hex_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                           dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "immutables": {"123": "0x1000000000"},
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")
+
+    def test_values_one_fail_all_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                       dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "immutables": {
+                "123": "6400000000000000000000000000000000000000000000000000000000000000",
+                "124": "0x6400000000000000000000000000000000000000000000000000000000000000"
+            }
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")
+
+########## Tests cborAuxdata field constraints ##########
+
+
+class TestObjectCborAuxdata:
+    @pytest.fixture(scope='function', autouse=True)
+    def setup(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
+        setup(connection, dummy_code, dummy_contract,
+              dummy_contract_deployment, dummy_compiled_contract)
+
+    def test_valid_field_value(self, connection, dummy_code, dummy_contract,
+                               dummy_contract_deployment, dummy_compiled_contract,
+                               dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "cborAuxdata": {"1": "0x00000000000000000000000000000000000000000000000000000000000000000000000000"}
+        })
+        dummy_verified_contract.insert(
+            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
+
+    def test_empty_object(self, connection, dummy_code, dummy_contract,
+                          dummy_contract_deployment, dummy_compiled_contract,
+                          dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "cborAuxdata": {}
+        })
+        dummy_verified_contract.insert(
+            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
+
+    @pytest.mark.parametrize("value", [None, [], ""], ids=["null", "array", "string"])
+    def test_invalid_type_fails(self, value, connection, dummy_code, dummy_contract,
+                                dummy_contract_deployment, dummy_compiled_contract,
+                                dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "cborAuxdata": value
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")
+
+    @pytest.mark.parametrize("value", [None, [], dict({})], ids=["null", "array", "object"])
+    def test_additional_properties_with_invalid_type_fails(self, value, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                                           dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "cborAuxdata": {"1": value}
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")
+
+    def test_values_without_0x_prefix_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                            dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "cborAuxdata": {"1": "00000000000000000000000000000000000000000000000000000000000000000000000000"}
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")
+
+    def test_values_not_valid_hex_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                        dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "cborAuxdata": {"1": "0xqwer0000000000000000000000000000000000000000000000000000000000000000000000"}
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")
+
+    def test_empty_hex_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "cborAuxdata": {"1": "0x"}
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")
+
+    def test_odd_length_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "cborAuxdata": {"1": "0x123"}
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")
+
+    def test_values_one_fail_all_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                       dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "cborAuxdata": {
+                "1": "0x00000000000000000000000000000000000000000000000000000000000000000000000000",
+                "2": "00000000000000000000000000000000000000000000000000000000000000000000000000"
+            }
+        })
         check_constraint_fails(
             lambda: dummy_verified_contract.insert(
                 connection, dummy_contract_deployment.id, dummy_compiled_contract.id),

--- a/tests/test_constraint_runtime_values.py
+++ b/tests/test_constraint_runtime_values.py
@@ -1,6 +1,7 @@
 from helpers import *
 
 
+@pytest.fixture(scope='function', autouse=True)
 def setup(connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
     dummy_code.insert(connection)
     dummy_contract.insert(
@@ -11,11 +12,6 @@ def setup(connection, dummy_code, dummy_contract, dummy_contract_deployment, dum
 
 
 class TestObject:
-    @pytest.fixture(scope='function', autouse=True)
-    def setup(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
-        setup(connection, dummy_code, dummy_contract,
-              dummy_contract_deployment, dummy_compiled_contract)
-
     def test_no_fields_are_required(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
         dummy_verified_contract.runtime_values = dict({})
         dummy_verified_contract.insert(
@@ -56,11 +52,6 @@ class TestObject:
 
 ########## Tests libraries field constraints ##########
 class TestObjectLibraries:
-    @pytest.fixture(scope='function', autouse=True)
-    def setup(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
-        setup(connection, dummy_code, dummy_contract,
-              dummy_contract_deployment, dummy_compiled_contract)
-
     def test_valid_field_value(self, connection, dummy_code, dummy_contract,
                                dummy_contract_deployment, dummy_compiled_contract,
                                dummy_verified_contract):
@@ -145,15 +136,9 @@ class TestObjectLibraries:
                 connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
             "runtime_values_object")
 
+
 ########## Tests immutables field constraints ##########
-
-
 class TestObjectImmutables:
-    @pytest.fixture(scope='function', autouse=True)
-    def setup(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
-        setup(connection, dummy_code, dummy_contract,
-              dummy_contract_deployment, dummy_compiled_contract)
-
     def test_valid_field_value(self, connection, dummy_code, dummy_contract,
                                dummy_contract_deployment, dummy_compiled_contract,
                                dummy_verified_contract):
@@ -238,15 +223,9 @@ class TestObjectImmutables:
                 connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
             "runtime_values_object")
 
+
 ########## Tests cborAuxdata field constraints ##########
-
-
 class TestObjectCborAuxdata:
-    @pytest.fixture(scope='function', autouse=True)
-    def setup(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
-        setup(connection, dummy_code, dummy_contract,
-              dummy_contract_deployment, dummy_compiled_contract)
-
     def test_valid_field_value(self, connection, dummy_code, dummy_contract,
                                dummy_contract_deployment, dummy_compiled_contract,
                                dummy_verified_contract):
@@ -339,15 +318,9 @@ class TestObjectCborAuxdata:
                 connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
             "runtime_values_object")
 
+
 ########## Tests callProtection field constraints ##########
-
-
 class TestObjectCallProtection:
-    @pytest.fixture(scope='function', autouse=True)
-    def setup(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
-        setup(connection, dummy_code, dummy_contract,
-              dummy_contract_deployment, dummy_compiled_contract)
-
     def test_valid_field_value(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
         dummy_verified_contract.runtime_values = dict({
             "callProtection": "0x4000000000000000000000000000000000000000"

--- a/tests/test_constraint_runtime_values.py
+++ b/tests/test_constraint_runtime_values.py
@@ -340,6 +340,8 @@ class TestObjectCborAuxdata:
             "runtime_values_object")
 
 ########## Tests callProtection field constraints ##########
+
+
 class TestObjectCallProtection:
     @pytest.fixture(scope='function', autouse=True)
     def setup(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):

--- a/tests/test_constraint_runtime_values.py
+++ b/tests/test_constraint_runtime_values.py
@@ -1,0 +1,59 @@
+from helpers import *
+
+
+class TestRuntimeValuesObjectConstraint:
+    @pytest.fixture(scope='function', autouse=True)
+    def setup(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
+        dummy_code.insert(connection)
+        dummy_contract.insert(
+            connection, dummy_code.code_hash, dummy_code.code_hash)
+        dummy_contract_deployment.insert(connection, dummy_contract.id)
+        dummy_compiled_contract.insert(
+            connection, dummy_code.code_hash, dummy_code.code_hash)
+
+    def test_no_fields_are_required(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({})
+        dummy_verified_contract.insert(
+            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
+
+    def test_expected_type_values(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "libraries": {"file1:lib1": "0x4000000000000000000000000000000000000000"},
+            "immutables": {"123": "0x0000000000000000000000000000000000000000000000000000000000000000"},
+            "cborAuxdata": {"1": "0x00000000000000000000000000000000000000000000000000000000000000000000000000"}
+        })
+        dummy_verified_contract.insert(
+            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
+
+    # This test shows that empty json objects instead of libraries are also allowed according to schema.
+    # TODO: should they actually be allowed?
+    def test_default_type_values(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "libraries": {},
+            "immutables": {},
+            "cborAuxdata": {}
+        })
+        dummy_verified_contract.insert(
+            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
+
+    def test_invalid_json_type_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values = "just a string"
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")
+
+    def test_constructor_arguments_field_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values["constructorArguments"] = dict({
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")
+
+    def test_unknown_field_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values['unknown_key'] = dict({})
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_object")


### PR DESCRIPTION
Add a check that only allowed keys are used inside `verified_contracts.creation_values` and `verified_contracts.runtime_values`. Allows for keys not to be present in the object.

Adds internal constraints for the values according to [json-schema](https://github.com/verifier-alliance/database-specs/blob/master/json-schemas/verified_contracts-values.json) (checks that values are valid hexes and have correct lengths)