### PR TITLE
Replace `compiled_contracts.sources` column with `source_codes` and `compiled_contracts_sources` tables

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -247,10 +247,10 @@ CREATE TABLE source_codes
 );
 
 /*
-    The `contracts_sources` table links a compiled_contract to its associated source files.
+    The `compiled_contracts_sources` table links a compiled_contract to its associated source files.
     This table contains a unique combination of compilation_id and path.
 */
-CREATE TABLE contracts_sources
+CREATE TABLE compiled_contracts_sources
 (
     id uuid NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
 
@@ -261,11 +261,11 @@ CREATE TABLE contracts_sources
     /* the file path associated with this source code in the compilation */
     path varchar NOT NULL,
 
-    CONSTRAINT contracts_sources_pseudo_pkey UNIQUE (compilation_id, path)
+    CONSTRAINT compiled_contracts_sources_pseudo_pkey UNIQUE (compilation_id, path)
 );
 
-CREATE INDEX contracts_sources_source_code_hash ON contracts_sources USING btree (source_code_hash);
-CREATE INDEX contracts_sources_compilation_id ON contracts_sources (compilation_id);
+CREATE INDEX compiled_contracts_sources_source_code_hash ON compiled_contracts_sources USING btree (source_code_hash);
+CREATE INDEX compiled_contracts_sources_compilation_id ON compiled_contracts_sources (compilation_id);
 
 /*
     The verified_contracts table links an on-chain contract with a compiled_contract

--- a/database.sql
+++ b/database.sql
@@ -218,16 +218,16 @@ CREATE INDEX compiled_contracts_creation_code_hash ON compiled_contracts USING b
 CREATE INDEX compiled_contracts_runtime_code_hash ON compiled_contracts USING btree (runtime_code_hash);
 
 /*
-    The `source_codes` table stores the source code related to the contracts.
-    It includes a hash of the source code and the code content itself.
+    The `sources` table stores the source code related to the contracts.
+    It includes hashes of the source code and the code content itself.
 */
-CREATE TABLE source_codes
+CREATE TABLE sources
 (
     /* the sha256 hash of the source code */
-    source_code_hash bytea NOT NULL PRIMARY KEY,
+    source_hash bytea NOT NULL PRIMARY KEY,
 
     /* the keccak256 hash of the source code */
-    source_code_hash_keccak bytea NOT NULL,
+    source_hash_keccak bytea NOT NULL,
 
     /* the actual source code content */
     content varchar NOT NULL,
@@ -240,7 +240,7 @@ CREATE TABLE source_codes
     created_by  varchar NOT NULL DEFAULT (current_user),
     updated_by  varchar NOT NULL DEFAULT (current_user),
 
-    CONSTRAINT source_code_hash_check CHECK (source_code_hash = digest(content, 'sha256'))
+    CONSTRAINT source_hash_check CHECK (source_hash = digest(content, 'sha256'))
 );
 
 /*
@@ -253,7 +253,7 @@ CREATE TABLE compiled_contracts_sources
 
     /* the specific compilation and the specific source */
     compilation_id uuid NOT NULL REFERENCES compiled_contracts(id),
-    source_code_hash bytea NOT NULL REFERENCES source_codes(source_code_hash),
+    source_hash bytea NOT NULL REFERENCES sources(source_hash),
 
     /* the file path associated with this source code in the compilation */
     path varchar NOT NULL,
@@ -261,7 +261,7 @@ CREATE TABLE compiled_contracts_sources
     CONSTRAINT compiled_contracts_sources_pseudo_pkey UNIQUE (compilation_id, path)
 );
 
-CREATE INDEX compiled_contracts_sources_source_code_hash ON compiled_contracts_sources USING btree (source_code_hash);
+CREATE INDEX compiled_contracts_sources_source_hash ON compiled_contracts_sources USING btree (source_hash);
 CREATE INDEX compiled_contracts_sources_compilation_id ON compiled_contracts_sources (compilation_id);
 
 /*
@@ -458,7 +458,7 @@ $$
                               ('contracts'),
                               ('contract_deployments'),
                               ('compiled_contracts'),
-                              ('source_codes'),
+                              ('sources'),
                               ('verified_contracts'))
             LOOP
                 EXECUTE format('CREATE TRIGGER insert_set_created_at
@@ -538,7 +538,7 @@ $$
                               ('contracts'),
                               ('contract_deployments'),
                               ('compiled_contracts'),
-                              ('source_codes'),
+                              ('sources'),
                               ('verified_contracts'))
             LOOP
                 EXECUTE format('CREATE TRIGGER insert_set_created_by

--- a/database.sql
+++ b/database.sql
@@ -229,9 +229,6 @@ CREATE TABLE source_codes
     /* the keccak256 hash of the source code */
     source_code_hash_keccak bytea NOT NULL,
 
-    /* the programming language of the source code */
-    language varchar NOT NULL,
-
     /* the actual source code content */
     content varchar NOT NULL,
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -76,7 +76,7 @@ class CompiledContract:
                     id, compiler, version, language, name, fully_qualified_name, 
                     compiler_settings, compilation_artifacts, creation_code_hash, creation_code_artifacts,
                     runtime_code_hash, runtime_code_artifacts)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """, (self.id, self.compiler, self.version, self.language, self.name, self.fully_qualified_name,
                   json.dumps(self.compiler_settings), json.dumps(
                       self.compilation_artifacts), creation_code_hash, json.dumps(self.creation_code_artifacts),

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -39,7 +39,6 @@ class CompiledContract:
     language = ""
     name = ""
     fully_qualified_name = ""
-    sources = dict()
     compiler_settings = dict()
     compilation_artifacts = dict()
     creation_code_artifacts = dict()
@@ -74,11 +73,11 @@ class CompiledContract:
         with connection.cursor() as cursor:
             cursor.execute("""
                 INSERT INTO compiled_contracts (
-                    id, compiler, version, language, name, fully_qualified_name, sources, 
+                    id, compiler, version, language, name, fully_qualified_name, 
                     compiler_settings, compilation_artifacts, creation_code_hash, creation_code_artifacts,
                     runtime_code_hash, runtime_code_artifacts)
                 VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-            """, (self.id, self.compiler, self.version, self.language, self.name, self.fully_qualified_name, json.dumps(self.sources),
+            """, (self.id, self.compiler, self.version, self.language, self.name, self.fully_qualified_name,
                   json.dumps(self.compiler_settings), json.dumps(
                       self.compilation_artifacts), creation_code_hash, json.dumps(self.creation_code_artifacts),
                   runtime_code_hash, json.dumps(self.runtime_code_artifacts)))


### PR DESCRIPTION
This PR adds the two new tables that will replace the `compiled_contracts.sources` column: `source_codes` and `compiled_contracts_sources`.

In `source_codes` we provide the source hashes (sha256,keccak256), the language (solidity,vyper,...) the content of the file and the standard timestamp and ownership fields; we use the file's sha256 as primary key. `language` is stored here to avoid having to join `compiled_contract` to find the language of that source.

`compiled_contracts_sources` is a many-to-many relationship table between `compiled_contract` and `source_codes` using their respective PK as foreign keys (`compilation_id->compiled_contract.id`, `source_code_hash->source_codes.source_codes`). In `compiled_contracts_sources` we also have the `path`, since it varies for every compilation. This table doesn't contain timestamp and ownership fields since it's an extension of the `compiled_contract` table.

## Diagram

![image](https://github.com/user-attachments/assets/dd4d0da5-c4c0-4fa7-a281-a41d5129922f)
