### PR TITLE
test: verified_contracts match related constraints

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -305,17 +305,7 @@ CREATE TABLE verified_contracts
 
     CONSTRAINT verified_contracts_pseudo_pkey UNIQUE (compilation_id, deployment_id),
 
-    CONSTRAINT verified_contracts_creation_values_is_object
-        CHECK (creation_values IS NULL OR jsonb_typeof(creation_values) = 'object'),
-    CONSTRAINT verified_contracts_creation_transformations_is_array
-        CHECK (creation_transformations IS NULL OR jsonb_typeof(creation_transformations) = 'array'),
-
-    CONSTRAINT verified_contracts_runtime_values_is_object
-        CHECK (runtime_values IS NULL OR jsonb_typeof(runtime_values) = 'object'),
-    CONSTRAINT verified_contracts_runtime_transformations_is_array
-        CHECK (runtime_transformations IS NULL OR jsonb_typeof(runtime_transformations) = 'array'),
-
-    CONSTRAINT verified_contracts_match_exists 
+    CONSTRAINT verified_contracts_match_exists
         CHECK (creation_match = true OR runtime_match = true),
     CONSTRAINT verified_contracts_creation_match_integrity
         CHECK ((creation_match = false AND creation_values IS NULL AND creation_transformations IS NULL AND creation_metadata_match IS NULL) OR

--- a/database.sql
+++ b/database.sql
@@ -687,19 +687,19 @@ $$ LANGUAGE plpgsql;
 
 ALTER TABLE verified_contracts
 ADD CONSTRAINT creation_values_object 
-CHECK (validate_creation_values(creation_values));
+CHECK (creation_values IS NULL OR validate_creation_values(creation_values));
 
 ALTER TABLE verified_contracts
 ADD CONSTRAINT runtime_values_object 
-CHECK (validate_runtime_values(runtime_values));
+CHECK (runtime_values IS NULL OR validate_runtime_values(runtime_values));
 
 ALTER TABLE verified_contracts
 ADD CONSTRAINT creation_transformations_array
-CHECK (validate_creation_transformations(creation_transformations));
+CHECK (creation_transformations IS NULL OR validate_creation_transformations(creation_transformations));
 
 ALTER TABLE verified_contracts
 ADD CONSTRAINT runtime_transformations_array
-CHECK (validate_runtime_transformations(runtime_transformations));
+CHECK (runtime_transformations IS NULL OR validate_runtime_transformations(runtime_transformations));
 
 /* 
     Set up timestamps related triggers. Used to enforce `created_at` and `updated_at` 

--- a/tests/test_table_verified_contracts.py
+++ b/tests/test_table_verified_contracts.py
@@ -1,0 +1,122 @@
+from helpers import *
+
+
+@pytest.fixture(scope='function', autouse=True)
+def setup(connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract):
+    dummy_code.insert(connection)
+    dummy_contract.insert(
+        connection, dummy_code.code_hash, dummy_code.code_hash)
+    dummy_contract_deployment.insert(connection, dummy_contract.id)
+    dummy_compiled_contract.insert(
+        connection, dummy_code.code_hash, dummy_code.code_hash)
+
+
+class TestTable:
+    def test_both_matches_are_true(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_match = True
+        dummy_verified_contract.creation_values = dict()
+        dummy_verified_contract.creation_transformations = []
+        dummy_verified_contract.creation_metadata_match = True
+
+        dummy_verified_contract.runtime_match = True
+        dummy_verified_contract.runtime_values = dict()
+        dummy_verified_contract.runtime_transformations = []
+        dummy_verified_contract.runtime_metadata_match = True
+
+        dummy_verified_contract.insert(
+            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
+
+    def test_creation_match_only_is_true(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_match = True
+        dummy_verified_contract.creation_values = dict()
+        dummy_verified_contract.creation_transformations = []
+        dummy_verified_contract.creation_metadata_match = True
+
+        dummy_verified_contract.runtime_match = False
+        dummy_verified_contract.runtime_values = Null
+        dummy_verified_contract.runtime_transformations = Null
+        dummy_verified_contract.runtime_metadata_match = Null
+
+        dummy_verified_contract.insert(
+            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
+
+    def test_runtime_match_only_is_true(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_match = False
+        dummy_verified_contract.creation_values = Null
+        dummy_verified_contract.creation_transformations = Null
+        dummy_verified_contract.creation_metadata_match = Null
+
+        dummy_verified_contract.runtime_match = True
+        dummy_verified_contract.runtime_values = dict()
+        dummy_verified_contract.runtime_transformations = []
+        dummy_verified_contract.runtime_metadata_match = True
+
+        dummy_verified_contract.insert(
+            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
+
+    def test_false_both_creation_and_runtime_matches_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_match = False
+        dummy_verified_contract.creation_values = Null
+        dummy_verified_contract.creation_transformations = Null
+        dummy_verified_contract.creation_metadata_match = Null
+
+        dummy_verified_contract.runtime_match = False
+        dummy_verified_contract.runtime_values = Null
+        dummy_verified_contract.runtime_transformations = Null
+        dummy_verified_contract.runtime_metadata_match = Null
+
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "verified_contracts_match_exists"
+        )
+
+    @pytest.mark.parametrize("field", ["creation_values", "creation_transformations", "creation_metadata_match"])
+    def test_creation_match_without_details_fails(self, field, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.__setattr__(field, Null)
+
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "verified_contracts_creation_match_integrity"
+        )
+
+    @pytest.mark.parametrize("field,value", [("creation_values", dict()), ("creation_transformations", []), ("creation_metadata_match", False)])
+    def test_no_creation_match_with_details_fails(self, field, value, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_match = False
+        dummy_verified_contract.creation_values = Null
+        dummy_verified_contract.creation_transformations = Null
+        dummy_verified_contract.creation_metadata_match = Null
+
+        dummy_verified_contract.__setattr__(field, value)
+
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "verified_contracts_creation_match_integrity"
+        )
+
+    @pytest.mark.parametrize("field", ["runtime_values", "runtime_transformations", "runtime_metadata_match"])
+    def test_runtime_match_without_details_fails(self, field, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.__setattr__(field, Null)
+
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "verified_contracts_runtime_match_integrity"
+        )
+
+    @pytest.mark.parametrize("field,value", [("runtime_values", dict()), ("runtime_transformations", []), ("runtime_metadata_match", False)])
+    def test_no_runtime_match_with_details_fails(self, field, value, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_match = False
+        dummy_verified_contract.runtime_values = Null
+        dummy_verified_contract.runtime_transformations = Null
+        dummy_verified_contract.runtime_metadata_match = Null
+
+        dummy_verified_contract.__setattr__(field, value)
+
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "verified_contracts_runtime_match_integrity"
+        )

--- a/tests/test_table_verified_contracts.py
+++ b/tests/test_table_verified_contracts.py
@@ -73,6 +73,11 @@ class TestTable:
 
     @pytest.mark.parametrize("field", ["creation_values", "creation_transformations", "creation_metadata_match"])
     def test_creation_match_without_details_fails(self, field, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.creation_match = True
+        dummy_verified_contract.creation_values = dict()
+        dummy_verified_contract.creation_transformations = []
+        dummy_verified_contract.creation_metadata_match = True
+
         dummy_verified_contract.__setattr__(field, Null)
 
         check_constraint_fails(
@@ -98,6 +103,11 @@ class TestTable:
 
     @pytest.mark.parametrize("field", ["runtime_values", "runtime_transformations", "runtime_metadata_match"])
     def test_runtime_match_without_details_fails(self, field, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_match = True
+        dummy_verified_contract.runtime_values = dict()
+        dummy_verified_contract.runtime_transformations = []
+        dummy_verified_contract.runtime_metadata_match = True
+
         dummy_verified_contract.__setattr__(field, Null)
 
         check_constraint_fails(


### PR DESCRIPTION
- Add tests for verified_contracts constraints related to matches integrity
- Fix failing creation_values and runtime_values constraints when `NULL` value is inserted