### PR TITLE
Update immutable transformation `insert` type for Vyper

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -606,7 +606,7 @@ CREATE OR REPLACE FUNCTION validate_transformations_immutable(object jsonb)
     RETURNS boolean AS
 $$
 BEGIN
-    RETURN validate_transformation_key_type(object, 'replace') AND validate_transformation_key_offset(object)
+    RETURN (validate_transformation_key_type(object, 'replace') OR validate_transformation_key_type(object, 'insert')) AND validate_transformation_key_offset(object)
         AND validate_transformation_key_id(object);
 END;
 $$ LANGUAGE plpgsql;

--- a/json-schemas/README.md
+++ b/json-schemas/README.md
@@ -136,7 +136,7 @@ The runtime transformations can only contain these as `"reason"`s and `"type"`s:
 
 - `{ "reason": "cborAuxdata", "type": "replace", "offset": 123, id: "0" }` Needs an `id` since there can be multiple auxdata transformations e.g. factories.
 - `{ "reason": "library", "type": "replace", "offset": 123, id: "contracts/order/OrderUtils.sol:OrderUtilsLib" }`
-- `{ "reason": "immutable", "type": "replace", "offset": 999, id: "2473" }` Needs an `id` for referencing multiple times and there can be multiple immutable transformations.
+- `{ "reason": "immutable", "type": "replace", "offset": 999, id: "2473" }` Needs an `id` for referencing multiple times and there can be multiple immutable transformations. Solidity contracts have `"replace"` type, while Vyper ones have `"insert"` because they are appended to the runtime bytecode.
 - `{ "reason": "callProtection", "type": "replace", "offset": 1 }`
 
 Example 1:

--- a/tests/test_constraint_runtime_transformations_json_schema.py
+++ b/tests/test_constraint_runtime_transformations_json_schema.py
@@ -192,6 +192,14 @@ class TestImmutable:
         dummy_verified_contract.insert(
             connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
 
+    def test_valid_value_insert(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_transformations = [
+            {"reason": "immutable", "type": "insert", "offset": 999, "id": "0"},
+        ]
+        dummy_verified_contract.insert(
+            connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
+
+
     def test_missing_key_type_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
         dummy_verified_contract.runtime_transformations = [
             {"reason": "immutable", "offset": 0, "id": "0"},
@@ -205,15 +213,6 @@ class TestImmutable:
     def test_invalid_key_type_type_fails(self, value, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
         dummy_verified_contract.runtime_transformations = [
             {"reason": "immutable", "type": value, "offset": 0, "id": "0"},
-        ]
-        check_constraint_fails(
-            lambda: dummy_verified_contract.insert(
-                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
-            "runtime_transformations_json_schema")
-
-    def test_invalid_key_type_value_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
-        dummy_verified_contract.runtime_transformations = [
-            {"reason": "immutable", "type": "insert", "offset": 0, "id": "0"},
         ]
         check_constraint_fails(
             lambda: dummy_verified_contract.insert(


### PR DESCRIPTION
Fixes https://github.com/ethereum/sourcify/issues/1802

Vyper contracts have their immutables appended to the onchain runtime bytecode, so this needs to be incorperated into the schema, tests, and docs.

After merging make sure the schemas in the deployed DBs are updated, specifically, we updated the function `validate_transformations_immutable`