### PR TITLE
Fix for Vyper immutables transformations

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -484,7 +484,7 @@ BEGIN
 
     IF is_jsonb_object(obj -> 'immutables') THEN
         RETURN bool_and(are_valid_values)
-            FROM (SELECT is_jsonb_string(value) AND is_valid_hex(value ->> 0, '+')
+            FROM (SELECT is_jsonb_string(value) AND is_valid_hex(value ->> 0, '+') as are_valid_values
                   FROM jsonb_each(obj -> 'immutables')) as subquery;
     ELSE
         RETURN false;

--- a/database.sql
+++ b/database.sql
@@ -484,7 +484,7 @@ BEGIN
 
     IF is_jsonb_object(obj -> 'immutables') THEN
         RETURN bool_and(are_valid_values)
-            FROM (SELECT is_jsonb_string(value) as are_valid_values
+            FROM (SELECT is_jsonb_string(value) AND is_valid_hex(value ->> 0, '+')
                   FROM jsonb_each(obj -> 'immutables')) as subquery;
     ELSE
         RETURN false;

--- a/database.sql
+++ b/database.sql
@@ -484,7 +484,7 @@ BEGIN
 
     IF is_jsonb_object(obj -> 'immutables') THEN
         RETURN bool_and(are_valid_values)
-            FROM (SELECT is_jsonb_string(value) as are_valid_values
+            FROM (SELECT is_jsonb_string(value)) as are_valid_values
                   FROM jsonb_each(obj -> 'immutables')) as subquery;
     ELSE
         RETURN false;

--- a/database.sql
+++ b/database.sql
@@ -484,7 +484,7 @@ BEGIN
 
     IF is_jsonb_object(obj -> 'immutables') THEN
         RETURN bool_and(are_valid_values)
-            FROM (SELECT is_jsonb_string(value)) as are_valid_values
+            FROM (SELECT is_jsonb_string(value) as are_valid_values
                   FROM jsonb_each(obj -> 'immutables')) as subquery;
     ELSE
         RETURN false;

--- a/database.sql
+++ b/database.sql
@@ -484,7 +484,7 @@ BEGIN
 
     IF is_jsonb_object(obj -> 'immutables') THEN
         RETURN bool_and(are_valid_values)
-            FROM (SELECT is_jsonb_string(value) AND is_valid_hex(value ->> 0, '{32}') as are_valid_values
+            FROM (SELECT is_jsonb_string(value) as are_valid_values
                   FROM jsonb_each(obj -> 'immutables')) as subquery;
     ELSE
         RETURN false;

--- a/tests/test_constraint_runtime_values_json_schema.py
+++ b/tests/test_constraint_runtime_values_json_schema.py
@@ -200,6 +200,16 @@ class TestObjectImmutables:
                 connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
             "runtime_values_json_schema")
 
+    def test_values_not_empty_hex_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
+                                        dummy_compiled_contract, dummy_verified_contract):
+        dummy_verified_contract.runtime_values = dict({
+            "immutables": {"123": "0x"},
+        })
+        check_constraint_fails(
+            lambda: dummy_verified_contract.insert(
+                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
+            "runtime_values_json_schema")
+
     def test_values_one_fail_all_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
                                        dummy_compiled_contract, dummy_verified_contract):
         dummy_verified_contract.runtime_values = dict({

--- a/tests/test_constraint_runtime_values_json_schema.py
+++ b/tests/test_constraint_runtime_values_json_schema.py
@@ -200,16 +200,6 @@ class TestObjectImmutables:
                 connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
             "runtime_values_json_schema")
 
-    def test_values_not_32_bytes_hex_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
-                                           dummy_compiled_contract, dummy_verified_contract):
-        dummy_verified_contract.runtime_values = dict({
-            "immutables": {"123": "0x1000000000"},
-        })
-        check_constraint_fails(
-            lambda: dummy_verified_contract.insert(
-                connection, dummy_contract_deployment.id, dummy_compiled_contract.id),
-            "runtime_values_json_schema")
-
     def test_values_one_fail_all_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment,
                                        dummy_compiled_contract, dummy_verified_contract):
         dummy_verified_contract.runtime_values = dict({


### PR DESCRIPTION
Vyper `immutables` transformation value is not limited of 32 bytes length. We should drop that part of the constraint in order to support Vyper contracts.