### PR TITLE
feat(compiled_contracts): add database constraints for compilation_artifacts.sources

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
         - name: Set up Python
           uses: actions/setup-python@v5
           with:
-            python-version: '3.x'
+            python-version: '3.12'
 
         - name: Install dependencies
           run: |

--- a/database.sql
+++ b/database.sql
@@ -404,8 +404,9 @@ BEGIN
        -- the corresponding value is expected to be an object with only the 'id' key
        is_jsonb_object(value) AND
        validate_json_object_keys(value, array ['id'], array []::text[]) AND
-       -- the value of 'id' key is expected to be an integer
-       is_jsonb_number(value -> 'id')
+       -- the value of 'id' key is expected to be a non-negative integer
+       is_jsonb_number(value -> 'id') AND
+       (value->>'id')::int >= 0
     )
     INTO are_object_values_valid
     FROM jsonb_each(obj);

--- a/tests/test_constraint_compilation_artifacts_json_schema.py
+++ b/tests/test_constraint_compilation_artifacts_json_schema.py
@@ -132,6 +132,15 @@ class TestObject:
                 connection, dummy_code.code_hash, dummy_code.code_hash),
             "compilation_artifacts_json_schema")
 
+    def test_sources_id_subkey_value_is_negative_fails(self, connection, dummy_code, dummy_compiled_contract):
+        dummy_compiled_contract.compilation_artifacts['sources'] = {
+            "file.sol": {"id": -1}}
+        check_constraint_fails(
+            lambda: dummy_compiled_contract.insert(
+                connection, dummy_code.code_hash, dummy_code.code_hash
+            ), "compilation_artifacts_json_schema"
+        )
+
     def test_sources_repetitive_id_subkey_values_fails(self, connection, dummy_code, dummy_compiled_contract):
         dummy_compiled_contract.compilation_artifacts['sources'] = {
             "file.sol": {"id": 0}, "file2.sol": {"id": 0}}

--- a/tests/test_constraint_compilation_artifacts_json_schema.py
+++ b/tests/test_constraint_compilation_artifacts_json_schema.py
@@ -84,12 +84,12 @@ class TestObject:
             lambda: dummy_compiled_contract.insert(connection, dummy_code.code_hash, dummy_code.code_hash), 'compilation_artifacts_json_schema')
 
     @pytest.mark.parametrize("value", [0, "", []], ids=["number", "string", "array"])
-    def test_compilation_artifacts_sources_invalid_type_fails(self, value, connection, dummy_code, dummy_compiled_contract):
+    def test_sources_invalid_type_fails(self, value, connection, dummy_code, dummy_compiled_contract):
         dummy_compiled_contract.compilation_artifacts['sources'] = value
         check_constraint_fails(
             lambda: dummy_compiled_contract.insert(connection, dummy_code.code_hash, dummy_code.code_hash), "compilation_artifacts_json_schema")
 
-    def test_compilation_artifacts_sources_file_name_empty_string_fails(self, connection, dummy_code, dummy_compiled_contract):
+    def test_sources_file_name_empty_string_fails(self, connection, dummy_code, dummy_compiled_contract):
         dummy_compiled_contract.compilation_artifacts['sources'] = {
             "file.sol": {"id": 0}, "": {"id": 1}}
         check_constraint_fails(
@@ -98,8 +98,8 @@ class TestObject:
             "compilation_artifacts_json_schema")
 
     @pytest.mark.parametrize("value", [None, 0, "", []], ids=["null", "number", "string", "array"])
-    def test_compilation_artifacts_sources_id_subkey_values_invalid_type_fails(self, value, connection, dummy_code,
-                                                                               dummy_compiled_contract):
+    def test_sources_id_subkey_values_invalid_type_fails(self, value, connection, dummy_code,
+                                                         dummy_compiled_contract):
         dummy_compiled_contract.compilation_artifacts['sources'] = {
             "file.sol": value}
         check_constraint_fails(
@@ -107,7 +107,7 @@ class TestObject:
                 connection, dummy_code.code_hash, dummy_code.code_hash),
             "compilation_artifacts_json_schema")
 
-    def test_compilation_artifacts_sources_missing_id_subkey_fails(self, connection, dummy_code, dummy_compiled_contract):
+    def test_sources_missing_id_subkey_fails(self, connection, dummy_code, dummy_compiled_contract):
         dummy_compiled_contract.compilation_artifacts['sources'] = {
             "file.sol": {}}
         check_constraint_fails(
@@ -115,7 +115,7 @@ class TestObject:
                 connection, dummy_code.code_hash, dummy_code.code_hash),
             "compilation_artifacts_json_schema")
 
-    def test_compilation_artifacts_sources_extra_subkey_fails(self, connection, dummy_code, dummy_compiled_contract):
+    def test_sources_extra_subkey_fails(self, connection, dummy_code, dummy_compiled_contract):
         dummy_compiled_contract.compilation_artifacts['sources'] = {
             "file.sol": {"id": 0, "extra": 1}}
         check_constraint_fails(
@@ -124,7 +124,7 @@ class TestObject:
             "compilation_artifacts_json_schema")
 
     @pytest.mark.parametrize("value", [None, "", [], dict()], ids=["null", "string", "array", "object"])
-    def test_compilation_artifacts_sources_id_subkey_invalid_value_type_fails(self, value, connection, dummy_code, dummy_compiled_contract):
+    def test_sources_id_subkey_value_type_is_not_number_fails(self, value, connection, dummy_code, dummy_compiled_contract):
         dummy_compiled_contract.compilation_artifacts['sources'] = {
             "file.sol": {"id": value}}
         check_constraint_fails(
@@ -132,7 +132,7 @@ class TestObject:
                 connection, dummy_code.code_hash, dummy_code.code_hash),
             "compilation_artifacts_json_schema")
 
-    def test_compilation_artifacts_sources_repetitive_id_subkey_values_fails(self, connection, dummy_code, dummy_compiled_contract):
+    def test_sources_repetitive_id_subkey_values_fails(self, connection, dummy_code, dummy_compiled_contract):
         dummy_compiled_contract.compilation_artifacts['sources'] = {
             "file.sol": {"id": 0}, "file2.sol": {"id": 0}}
         check_constraint_fails(

--- a/tests/test_constraint_compilation_artifacts_json_schema.py
+++ b/tests/test_constraint_compilation_artifacts_json_schema.py
@@ -37,7 +37,7 @@ class TestObject:
             "abi": "",
             "userdoc": [""],
             "devdoc": {"devdoc": ["value"]},
-            "sources": [],
+            "sources": {"file.sol": {"id": 0}},
             "storageLayout": None
         })
         dummy_compiled_contract.insert(
@@ -82,3 +82,60 @@ class TestObject:
         dummy_compiled_contract.compilation_artifacts['unknown_key'] = None
         check_constraint_fails(
             lambda: dummy_compiled_contract.insert(connection, dummy_code.code_hash, dummy_code.code_hash), 'compilation_artifacts_json_schema')
+
+    @pytest.mark.parametrize("value", [0, "", []], ids=["number", "string", "array"])
+    def test_compilation_artifacts_sources_invalid_type_fails(self, value, connection, dummy_code, dummy_compiled_contract):
+        dummy_compiled_contract.compilation_artifacts['sources'] = value
+        check_constraint_fails(
+            lambda: dummy_compiled_contract.insert(connection, dummy_code.code_hash, dummy_code.code_hash), "compilation_artifacts_json_schema")
+
+    def test_compilation_artifacts_sources_file_name_empty_string_fails(self, connection, dummy_code, dummy_compiled_contract):
+        dummy_compiled_contract.compilation_artifacts['sources'] = {
+            "file.sol": {"id": 0}, "": {"id": 1}}
+        check_constraint_fails(
+            lambda: dummy_compiled_contract.insert(
+                connection, dummy_code.code_hash, dummy_code.code_hash),
+            "compilation_artifacts_json_schema")
+
+    @pytest.mark.parametrize("value", [None, 0, "", []], ids=["null", "number", "string", "array"])
+    def test_compilation_artifacts_sources_id_subkey_values_invalid_type_fails(self, value, connection, dummy_code,
+                                                                               dummy_compiled_contract):
+        dummy_compiled_contract.compilation_artifacts['sources'] = {
+            "file.sol": value}
+        check_constraint_fails(
+            lambda: dummy_compiled_contract.insert(
+                connection, dummy_code.code_hash, dummy_code.code_hash),
+            "compilation_artifacts_json_schema")
+
+    def test_compilation_artifacts_sources_missing_id_subkey_fails(self, connection, dummy_code, dummy_compiled_contract):
+        dummy_compiled_contract.compilation_artifacts['sources'] = {
+            "file.sol": {}}
+        check_constraint_fails(
+            lambda: dummy_compiled_contract.insert(
+                connection, dummy_code.code_hash, dummy_code.code_hash),
+            "compilation_artifacts_json_schema")
+
+    def test_compilation_artifacts_sources_extra_subkey_fails(self, connection, dummy_code, dummy_compiled_contract):
+        dummy_compiled_contract.compilation_artifacts['sources'] = {
+            "file.sol": {"id": 0, "extra": 1}}
+        check_constraint_fails(
+            lambda: dummy_compiled_contract.insert(
+                connection, dummy_code.code_hash, dummy_code.code_hash),
+            "compilation_artifacts_json_schema")
+
+    @pytest.mark.parametrize("value", [None, "", [], dict()], ids=["null", "string", "array", "object"])
+    def test_compilation_artifacts_sources_id_subkey_invalid_value_type_fails(self, value, connection, dummy_code, dummy_compiled_contract):
+        dummy_compiled_contract.compilation_artifacts['sources'] = {
+            "file.sol": {"id": value}}
+        check_constraint_fails(
+            lambda: dummy_compiled_contract.insert(
+                connection, dummy_code.code_hash, dummy_code.code_hash),
+            "compilation_artifacts_json_schema")
+
+    def test_compilation_artifacts_sources_repetitive_id_subkey_values_fails(self, connection, dummy_code, dummy_compiled_contract):
+        dummy_compiled_contract.compilation_artifacts['sources'] = {
+            "file.sol": {"id": 0}, "file2.sol": {"id": 0}}
+        check_constraint_fails(
+            lambda: dummy_compiled_contract.insert(
+                connection, dummy_code.code_hash, dummy_code.code_hash),
+            "compilation_artifacts_json_schema")

--- a/tests/test_constraint_runtime_transformations_json_schema.py
+++ b/tests/test_constraint_runtime_transformations_json_schema.py
@@ -199,7 +199,6 @@ class TestImmutable:
         dummy_verified_contract.insert(
             connection, dummy_contract_deployment.id, dummy_compiled_contract.id)
 
-
     def test_missing_key_type_fails(self, connection, dummy_code, dummy_contract, dummy_contract_deployment, dummy_compiled_contract, dummy_verified_contract):
         dummy_verified_contract.runtime_transformations = [
             {"reason": "immutable", "offset": 0, "id": "0"},


### PR DESCRIPTION
Enhance `validate_compilation_artifacts` constraint to check that `sources` key has the following format: `{"file_name": {"id": 0}}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced validation for compilation artifacts sources in the database
	- Added comprehensive checks for source file integrity and structure

- **Tests**
	- Expanded test coverage for compilation artifacts sources
	- Added multiple test cases to validate source file constraints

- **Bug Fixes**
	- Improved data validation to prevent invalid source file entries
	- Ensured unique and correctly formatted source file identifiers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->