### PR TITLE
docs(schema): note version may be a composite multi-binary toolchain string

### DIFF
--- a/migrations/20250717103432_database.sql
+++ b/migrations/20250717103432_database.sql
@@ -166,7 +166,11 @@ CREATE TABLE compiled_contracts
         the syntax ('solidity', 'vyper', 'yul'). there may be future compilers which aren't solc
         but can still compile solidity, which is why we need to differentiate the two
 
-        the version should uniquely identify the compiler
+        the version should uniquely identify the compiler. for single-binary compilers this is
+        the plain compiler version (e.g. solc '0.8.26+commit.8a97fa7a', vyper 'v0.3.10'). for
+        toolchains built from multiple binaries it may be a composite string that identifies the
+        whole toolchain — e.g. zksync's zksolc drives a separate solc backend, and is recorded as
+        'zksolc:<zksolcVersion>;solc:<solcVersion>' (e.g. 'zksolc:1.5.10;solc:0.8.26-1.0.2')
     */
     compiler    VARCHAR NOT NULL,
     version     VARCHAR NOT NULL,


### PR DESCRIPTION
Clarifies the `compiled_contracts.version` column comment: it is not always a single compiler version. Toolchains built from multiple binaries store a composite string identifying the whole toolchain.

Concrete example: ZKsync's `zksolc` drives a separate `solc` backend, so its version is recorded as `zksolc:<zksolcVersion>;solc:<solcVersion>` (e.g. `zksolc:1.5.10;solc:0.8.26-1.0.2`). This keeps the existing intent ("the version should uniquely identify the compiler") while covering multi-binary toolchains.

Comment-only change — does not affect the generated `database.sql` dump.

Context: this convention comes from the zksolc/EraVM verification work in Sourcify: https://github.com/argotorg/sourcify/pull/2788

🤖 Generated with [Claude Code](https://claude.com/claude-code)
